### PR TITLE
Fix order submission for single leg orders

### DIFF
--- a/accounts-trading.go
+++ b/accounts-trading.go
@@ -39,40 +39,6 @@ var (
 	// endpointPreviewOrder  string = accountEndpoint + "/accounts/%s/previewOrder"
 	// endpointTransactions string = accountEndpoint + "/accounts/%s/transactions"
 	endpointTransaction string = accountEndpoint + "/accounts/%s/transactions/%s"
-
-	OrderTemplate = `
-{
-  "orderType": "%s",
-  "session": "%s",
-  "duration": "%s",
-  "orderStrategyType": "%s",
-  "orderLegCollection": [
-    %s
-  ]
-}
-`
-
-	LegTemplate = `
-{
-  "instruction": "%s",
-  "quantity": %d,
-  "instrument": {
-    "symbol": "%s",
-    "assetType": "%s"
-  }
-}
-`
-
-	LegTemplateLast = `
-{
-  "instruction": "%s",
-  "quantity": %d,
-  "instrument": {
-    "symbol": "%s",
-    "assetType": "%s"
-  }
-}
-`
 )
 
 // Create a new Market order

--- a/accounts-trading.go
+++ b/accounts-trading.go
@@ -115,53 +115,55 @@ func Strategy(strategy string) SingleLegOrderComposition {
 // Set SingleLegOrder.Instruction
 func Instruction(instruction string) SingleLegOrderComposition {
 	return func(order *SingleLegOrder) {
-		order.Instruction = instruction
+		if len(order.OrderLegCollection) == 0 {
+			order.OrderLegCollection = append(order.OrderLegCollection, OrderLeg{})
+		}
+		order.OrderLegCollection[0].Instruction = instruction
 	}
 }
 
 // Set SingleLegOrder.Quantity
 func Quantity(quantity int) SingleLegOrderComposition {
 	return func(order *SingleLegOrder) {
-		order.Quantity = quantity
+		if len(order.OrderLegCollection) == 0 {
+			order.OrderLegCollection = append(order.OrderLegCollection, OrderLeg{})
+		}
+		order.OrderLegCollection[0].Quantity = quantity
 	}
 }
 
 // Set SingleLegOrder.Instrument
 func Instrument(instrument SimpleOrderInstrument) SingleLegOrderComposition {
 	return func(order *SingleLegOrder) {
-		order.Instrument = instrument
-	}
-}
-
-func marshalSingleLegOrder(order *SingleLegOrder) string {
-	return fmt.Sprintf(OrderTemplate, order.OrderType, order.Session, order.Duration, order.Strategy, fmt.Sprintf(LegTemplate, order.Instruction, order.Quantity, order.Instrument.Symbol, order.Instrument.AssetType))
-}
-
-func marshalMultiLegOrder(order *MultiLegOrder) string {
-	var legs string
-	// UNTESTED
-	for i, leg := range order.OrderLegCollection {
-		if i != len(order.OrderLegCollection)-1 {
-			legs += fmt.Sprintf(LegTemplate, leg.Instruction, leg.Quantity, leg.Instrument.Symbol, leg.Instrument.AssetType)
-		} else {
-			legs += fmt.Sprintf(LegTemplateLast, leg.Instruction, leg.Quantity, leg.Instrument.Symbol, leg.Instrument.AssetType)
+		if len(order.OrderLegCollection) == 0 {
+			order.OrderLegCollection = append(order.OrderLegCollection, OrderLeg{})
 		}
+		order.OrderLegCollection[0].Instrument = instrument
 	}
-	return fmt.Sprintf(OrderTemplate)
 }
 
 // Submit a single-leg order for the specified encrypted account ID
 func (agent *Agent) SubmitSingleLegOrder(hashValue string, order *SingleLegOrder) error {
-	orderJson := marshalSingleLegOrder(order)
-	req, err := http.NewRequest("POST", fmt.Sprintf(endpointAccountOrders, hashValue), strings.NewReader(orderJson))
+	orderJson, err := sonic.Marshal(order)
+	if err != nil {
+		return err
+	}
+	fmt.Println(string(orderJson))
+	req, err := http.NewRequest("POST", fmt.Sprintf(endpointAccountOrders, hashValue), strings.NewReader(string(orderJson)))
 	if err != nil {
 		return err
 	}
 	req.Header.Set("Content-Type", "application/json")
-	_, err = agent.Handler(req)
+	resp, err := agent.Handler(req)
 	if err != nil {
 		return err
 	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		fmt.Println("Error reading response body")
+	}
+	fmt.Println(string(body))
+	fmt.Println(resp.StatusCode)
 	return nil
 }
 

--- a/accounts-trading.go
+++ b/accounts-trading.go
@@ -55,23 +55,23 @@ var (
 	LegTemplate = `
 {
   "instruction": "%s",
-  "quantity": %f,
+  "quantity": %d,
   "instrument": {
     "symbol": "%s",
     "assetType": "%s"
   }
-},
+}
 `
 
 	LegTemplateLast = `
 {
   "instruction": "%s",
-  "quantity": %f,
+  "quantity": %d,
   "instrument": {
     "symbol": "%s",
     "assetType": "%s"
   }
-},
+}
 `
 )
 
@@ -120,7 +120,7 @@ func Instruction(instruction string) SingleLegOrderComposition {
 }
 
 // Set SingleLegOrder.Quantity
-func Quantity(quantity float32) SingleLegOrderComposition {
+func Quantity(quantity int) SingleLegOrderComposition {
 	return func(order *SingleLegOrder) {
 		order.Quantity = quantity
 	}

--- a/accounts-trading_types.go
+++ b/accounts-trading_types.go
@@ -285,6 +285,7 @@ type FullOrderLeg struct {
 }
 
 type SingleLegOrder struct {
+<<<<<<< Updated upstream
 	OrderType   string `default:"MARKET"`
 	Session     string `default:"NORMAL"`
 	Duration    string `default:"DAY"`
@@ -292,6 +293,19 @@ type SingleLegOrder struct {
 	Instruction string
 	Quantity    int
 	Instrument  SimpleOrderInstrument
+=======
+	OrderType          string     `json:"orderType"`
+	Session            string     `json:"session"`
+	Duration           string     `json:"duration"`
+	Strategy           string     `json:"orderStrategyType"`
+	OrderLegCollection []OrderLeg `json:"orderLegCollection"`
+}
+
+type OrderLeg struct {
+	Instruction string                `json:"instruction"`
+	Quantity    int                   `json:"quantity"`
+	Instrument  SimpleOrderInstrument `json:"instrument"`
+>>>>>>> Stashed changes
 }
 
 type MultiLegOrder struct {
@@ -309,8 +323,8 @@ type SimpleOrderLeg struct {
 }
 
 type SimpleOrderInstrument struct {
-	Symbol    string
-	AssetType string // EQUITY
+	Symbol    string `json:"symbol"`
+	AssetType string `json:"assetType"`
 }
 
 type (

--- a/accounts-trading_types.go
+++ b/accounts-trading_types.go
@@ -290,7 +290,7 @@ type SingleLegOrder struct {
 	Duration    string `default:"DAY"`
 	Strategy    string `default:"SINGLE"`
 	Instruction string
-	Quantity    float32
+	Quantity    int
 	Instrument  SimpleOrderInstrument
 }
 
@@ -304,7 +304,7 @@ type MultiLegOrder struct {
 
 type SimpleOrderLeg struct {
 	Instruction string
-	Quantity    float32
+	Quantity    int
 	Instrument  SimpleOrderInstrument
 }
 

--- a/accounts-trading_types.go
+++ b/accounts-trading_types.go
@@ -285,15 +285,6 @@ type FullOrderLeg struct {
 }
 
 type SingleLegOrder struct {
-<<<<<<< Updated upstream
-	OrderType   string `default:"MARKET"`
-	Session     string `default:"NORMAL"`
-	Duration    string `default:"DAY"`
-	Strategy    string `default:"SINGLE"`
-	Instruction string
-	Quantity    int
-	Instrument  SimpleOrderInstrument
-=======
 	OrderType          string     `json:"orderType"`
 	Session            string     `json:"session"`
 	Duration           string     `json:"duration"`
@@ -305,7 +296,6 @@ type OrderLeg struct {
 	Instruction string                `json:"instruction"`
 	Quantity    int                   `json:"quantity"`
 	Instrument  SimpleOrderInstrument `json:"instrument"`
->>>>>>> Stashed changes
 }
 
 type MultiLegOrder struct {

--- a/utils.go
+++ b/utils.go
@@ -327,6 +327,8 @@ func (agent *Agent) Handler(req *http.Request) (*http.Response, error) {
 	switch true {
 	case resp.StatusCode == 200:
 		return resp, nil
+	case resp.StatusCode == 201:
+		return resp, nil
 	case resp.StatusCode == 401:
 		body, err := io.ReadAll(resp.Body)
 		isErrNil(err)


### PR DESCRIPTION
Was getting strange errors and took a while to debug (error handling should probably expose the api response for easier debugability) some of the issues:

* it seems like `POST /accounts/{accountNumber}/orders` returns a `201` response code to indicate success. (see [doc](https://developer.schwab.com/products/trader-api--individual/details/specifications/Retail%20Trader%20API%20Production))
* the order quantity in the api request body has to be an integer (see [docs](https://developer.schwab.com/products/trader-api--individual/details/specifications/Retail%20Trader%20API%20Production)). 
* the trailing comma in the `LegTemplate` was causing issues


I've changed:

* the order submission to use `sonic.Marshal` (as it's used in other places in this codebase) instead of fmt.Sprintf . 
* the Quantity for `SingleLegOrder` to be an int to conform with the api spec 
* the struct to marshal correctly. I noted there are also other structs that don't seem to be fully implemented yet (currently in the works?) so I didn't modify them however if they're in-the-works then it'd make sense to have them follow the same pattern. 
* added 201 as an acceptable response code to agent.Handler


Here is the order submission request body before and after these updates:

Before:
```
{
  "orderType": "MARKET",
  "session": "NORMAL",
  "duration": "DAY",
  "orderStrategyType": "SINGLE",
  "orderLegCollection": [
    
{
  "instruction": "BUY",
  "quantity": 1.000000,
  "instrument": {
    "symbol": "AAPL",
    "assetType": "EQUITY"
  }
},

  ]
}

{"time":"2025-02-20T20:21:29.210308705-05:00","level":"ERROR","msg":"Failed to submit order","!BADKEY":"server is freaking out: server is freaking out"}
```

after:

```
{"orderType":"MARKET","session":"NORMAL","duration":"DAY","orderStrategyType":"SINGLE","orderLegCollection":[{"instruction":"BUY","quantity":1,"instrument":{"symbol":"GOOG","assetType":"EQUITY"}}]}
 
201
```

:beers: 